### PR TITLE
[bundlewatch] fix bundlewatch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,4 +29,4 @@ jobs:
           CI_REPO_OWNER: sylcastaing
           CI_REPO_NAME: hass-qubino-flush-pilot-wire-card
           CI_COMMIT_SHA: ${{ github.sha }}
-          CI_BRANCH_BASE: ${{ github.ref }}
+          CI_BRANCH: ${{ github.ref }}


### PR DESCRIPTION
Bundlewatch error on CI :

```
Run npm run bundlewatch

> hass-qubino-flush-pilot-wire-card@0.0.1 bundlewatch /home/runner/work/hass-qubino-flush-pilot-wire-card/hass-qubino-flush-pilot-wire-card
> bundlewatch

[WARNING] The ci.repoCurrentBranch was not supplied, bundlewatch results with not be saved:
    Learn more at: https://bundlewatch.io/
            
[INFO] Retrieving comparison
[ERROR] Unable to fetch fileDetails for baseBranch=refs/heads/reduce-bundle-size from https://service.bundlewatch.io/store code=Request failed with status code 404

Result breakdown at: https://ja2r7.app.goo.gl/uQ72

PASS ./dist/qubino-flush-wire-pilot.js: 15.91KB < 50KB (gzip)

bundlewatch PASS
Everything is in check (+15.91KB, -0B)
```